### PR TITLE
Lightning gun softlock fix + Shotgun pitch improvement + MP Marauders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.bak
 *.pk7
 *.7z
-*.bat
 
 # folders with big bulky things that shouldn't go on git like psd files
 /artsrc/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.bak
 *.pk7
 *.7z
+*.bat
 
 # folders with big bulky things that shouldn't go on git like psd files
 /artsrc/*

--- a/metadoom-dev/actors/weapons/metacore.zsc
+++ b/metadoom-dev/actors/weapons/metacore.zsc
@@ -200,6 +200,9 @@ Class MetaDoomWeapon : Weapon
 		}
 		
 		let psp = player.GetPSprite(PSP_WEAPON);
+		
+		if ( psp.y < WEAPONTOP ) psp.y = WEAPONTOP; // [Py] in case weapon offsets cause the weapon to go above the usual height (i.e. lightning gun offsets)
+		
 		if (player.morphTics || (player.cheats & CF_INSTANTWEAPSWITCH))
 			psp.y = WEAPONBOTTOM;
 		else

--- a/metadoom-dev/actors/weapons/metashotgun.zsc
+++ b/metadoom-dev/actors/weapons/metashotgun.zsc
@@ -116,15 +116,15 @@ class MetaShotgun : MetaDoomWeapon
 			A_GunFlash();
 			A_TakeInventory("Shell", 4);
 		}
-		STG1 J 1 bright Offset(0,45) A_SetPitch(pitch-4);
-		STG1 J 1 bright Offset(0,48) A_SetPitch(pitch-4);
+		STG1 J 1 bright Offset(0,45) A_SetViewPitch(ViewPitch-4, SPF_INTERPOLATE);
+		STG1 J 1 bright Offset(0,48) A_SetViewPitch(ViewPitch-4, SPF_INTERPOLATE);
 		STG1 K 2 bright Offset(0,48);
-		STG1 K 1 bright Offset(0,46) A_SetPitch(pitch+1);
-		STG1 L 1 bright Offset(0,44) A_SetPitch(pitch+1);
-		STG1 L 1 Offset(0,42) A_SetPitch(pitch+1);
-		STG1 D 1 Offset(0,38) A_SetPitch(pitch+1);
-		STG1 D 1 Offset(0,36) A_SetPitch(pitch+2);
-		STG1 A 1 Offset(0,34) A_SetPitch(pitch+2);
+		STG1 K 1 bright Offset(0,46) A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE);
+		STG1 L 1 bright Offset(0,44) A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE);
+		STG1 L 1 Offset(0,42) A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE);
+		STG1 D 1 Offset(0,38) A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE);
+		STG1 D 1 Offset(0,36) A_SetViewPitch(ViewPitch+2, SPF_INTERPOLATE);
+		STG1 A 1 Offset(0,34) A_SetViewPitch(ViewPitch+2, SPF_INTERPOLATE);
 		STG1 A 1 Offset(0,33);
 		STG1 A 3 Offset(0,32);
 		STG1 M 1 Offset(-4,32);
@@ -160,14 +160,14 @@ class MetaShotgun : MetaDoomWeapon
 		Stop;
 		
 	Overlay.Fire:
-		TNT1 B 1 { A_WeaponOffset(0,45, WOF_INTERPOLATE); A_SetPitch(pitch-2, SPF_INTERPOLATE); }
-		TNT1 B 1 { A_WeaponOffset(0,42,WOF_INTERPOLATE); A_SetPitch(pitch-2, SPF_INTERPOLATE); }
+		TNT1 B 1 { A_WeaponOffset(0,45, WOF_INTERPOLATE); A_SetViewPitch(ViewPitch-2, SPF_INTERPOLATE); }
+		TNT1 B 1 { A_WeaponOffset(0,42,WOF_INTERPOLATE); A_SetViewPitch(ViewPitch-2, SPF_INTERPOLATE); }
 		TNT1 C 1 A_WeaponOffset(0,40,WOF_INTERPOLATE);
 		TNT1 C 1 A_WeaponOffset(0,38,WOF_INTERPOLATE);
-		TNT1 D 1 { A_WeaponOffset(0,36,WOF_INTERPOLATE); A_SetPitch(pitch+1, SPF_INTERPOLATE); }
-		TNT1 E 2 { A_WeaponOffset(0,34,WOF_INTERPOLATE); A_SetPitch(pitch+1, SPF_INTERPOLATE); }
-		TNT1 F 2 { A_WeaponOffset(0,32,WOF_INTERPOLATE); A_SetPitch(pitch+1, SPF_INTERPOLATE); }
-		TNT1 G 2 A_SetPitch(pitch+1, SPF_INTERPOLATE);
+		TNT1 D 1 { A_WeaponOffset(0,36,WOF_INTERPOLATE); A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE); }
+		TNT1 E 2 { A_WeaponOffset(0,34,WOF_INTERPOLATE); A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE); }
+		TNT1 F 2 { A_WeaponOffset(0,32,WOF_INTERPOLATE); A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE); }
+		TNT1 G 2 A_SetViewPitch(ViewPitch+1, SPF_INTERPOLATE);
 		TNT1 A -1;
 		stop;
 	}

--- a/metadoom-dev/zscript/codex/metacodex_event.zsc
+++ b/metadoom-dev/zscript/codex/metacodex_event.zsc
@@ -17,7 +17,7 @@ Class MetaCodex_Event : EventHandler
 		{
 			return;
 		}
-		if ( Meta_ThingExists(e.Thing.GetClassName()) && Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()) )
+		if ( !multiplayer && Meta_ThingExists(e.Thing.GetClassName()) && Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()) )
 		{
 			if(e.Thing.target.player!=null&&e.Thing.target.player==players[consoleplayer]&&!e.Thing.target.FindInventory("MetaCodex_"..e.Thing.GetClassName()))
 			{

--- a/metadoom-dev/zscript/codex/metacodex_event.zsc
+++ b/metadoom-dev/zscript/codex/metacodex_event.zsc
@@ -13,11 +13,11 @@ Class MetaCodex_Event : EventHandler
 	}
 	override void WorldThingDied(WorldEvent e)
 	{
-		if(e.Thing.target==null||!(e.Thing.target is "PlayerPawn"))
+		if ( e.Thing.target==null || !(e.Thing.target is "PlayerPawn") )
 		{
 			return;
 		}
-		if(!multiplayer && Meta_ThingExists(e.Thing.GetClassName())&&Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()))
+		if ( Meta_ThingExists(e.Thing.GetClassName()) && Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()) )
 		{
 			if(e.Thing.target.player!=null&&e.Thing.target.player==players[consoleplayer]&&!e.Thing.target.FindInventory("MetaCodex_"..e.Thing.GetClassName()))
 			{

--- a/metadoom-dev/zscript/codex/metacodex_event.zsc
+++ b/metadoom-dev/zscript/codex/metacodex_event.zsc
@@ -13,11 +13,11 @@ Class MetaCodex_Event : EventHandler
 	}
 	override void WorldThingDied(WorldEvent e)
 	{
-		if ( e.Thing.target==null || !(e.Thing.target is "PlayerPawn") )
+		if(e.Thing.target==null||!(e.Thing.target is "PlayerPawn"))
 		{
 			return;
 		}
-		if ( Meta_ThingExists(e.Thing.GetClassName()) && Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()) )
+		if(!multiplayer && Meta_ThingExists(e.Thing.GetClassName())&&Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()))
 		{
 			if(e.Thing.target.player!=null&&e.Thing.target.player==players[consoleplayer]&&!e.Thing.target.FindInventory("MetaCodex_"..e.Thing.GetClassName()))
 			{

--- a/metadoom-dev/zscript/codex/metacodex_event.zsc
+++ b/metadoom-dev/zscript/codex/metacodex_event.zsc
@@ -13,11 +13,11 @@ Class MetaCodex_Event : EventHandler
 	}
 	override void WorldThingDied(WorldEvent e)
 	{
-		if(e.Thing.target==null||!(e.Thing.target is "PlayerPawn"))
+		if ( e.Thing.target==null||!(e.Thing.target is "PlayerPawn") )
 		{
 			return;
 		}
-		if(!multiplayer && Meta_ThingExists(e.Thing.GetClassName())&&Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()))
+		if ( Meta_ThingExists(e.Thing.GetClassName()) && Meta_ThingExists("MetaCodex_"..e.Thing.GetClassName()) )
 		{
 			if(e.Thing.target.player!=null&&e.Thing.target.player==players[consoleplayer]&&!e.Thing.target.FindInventory("MetaCodex_"..e.Thing.GetClassName()))
 			{

--- a/metadoom-dev/zscript/metamarauder.zsc
+++ b/metadoom-dev/zscript/metamarauder.zsc
@@ -30,7 +30,7 @@ Class MetaMarauderSpawnScript : EventHandler
 		}
 		
 		// are we in single player? and are we re-entering a hub level?
-		if (!multiplayer && !deathmatch && e.IsReopen == false && meta_marauders)
+		if ( !deathmatch && e.IsReopen == false && meta_marauders )
 		{
 			ThinkerIterator it = ThinkerIterator.Create("PlayerPawn");
 			Actor mo;


### PR DESCRIPTION
- The lightning gun (and potentially other weapons) should no longer softlock when trying to swap between weapons.
- Shotgun pitch changes now done with A_SetViewPitch to remove the stuttering when trying to look side-to-side
- Marauders spawn in multiplayer now! I've played with co-op enabled marauders for quite a while now and they work well, no issues detected